### PR TITLE
Add stop logging API

### DIFF
--- a/toolargetool/src/main/java/com/gu/toolargetool/FragmentSavedStateLogger.java
+++ b/toolargetool/src/main/java/com/gu/toolargetool/FragmentSavedStateLogger.java
@@ -18,6 +18,7 @@ public class FragmentSavedStateLogger extends FragmentManager.FragmentLifecycleC
     private final int priority;
     @NonNull private final String tag;
     @NonNull private final Map<Fragment, Bundle> savedStates = new HashMap<>();
+    private boolean isLogging = true;
 
     public FragmentSavedStateLogger(int priority, @NonNull String tag) {
         this.priority = priority;
@@ -30,7 +31,9 @@ public class FragmentSavedStateLogger extends FragmentManager.FragmentLifecycleC
 
     @Override
     public void onFragmentSaveInstanceState(FragmentManager fm, Fragment f, Bundle outState) {
-        savedStates.put(f, outState);
+        if (isLogging) {
+            savedStates.put(f, outState);
+        }
     }
 
     @Override
@@ -43,5 +46,13 @@ public class FragmentSavedStateLogger extends FragmentManager.FragmentLifecycleC
             }
             log(message);
         }
+    }
+
+    void startLogging() {
+        isLogging = true;
+    }
+
+    void stopLogging() {
+        isLogging = false;
     }
 }

--- a/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.java
+++ b/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.HashMap;
@@ -22,7 +21,7 @@ import java.util.Map;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class TooLargeTool {
 
-    @Nullable private static ActivitySavedStateLogger logger;
+    private static ActivitySavedStateLogger logger;
 
     private TooLargeTool() {
         // Static only
@@ -164,8 +163,17 @@ public final class TooLargeTool {
     public static void startLogging(Application application, int priority, @NonNull String tag) {
         if (logger == null) {
             logger = new ActivitySavedStateLogger(priority, tag, true);
-            application.registerActivityLifecycleCallbacks(logger);
+        } else {
+            logger.setPriority(priority);
+            logger.setTag(tag);
         }
+
+        if (logger.isLogging()) {
+            return;
+        }
+
+        logger.startLogging();
+        application.registerActivityLifecycleCallbacks(logger);
     }
 
     /**
@@ -174,14 +182,15 @@ public final class TooLargeTool {
      * @param application to stop logging
      */
     public static void stopLogging(Application application) {
-        if (logger != null) {
-            application.unregisterActivityLifecycleCallbacks(logger);
-            logger.stopLogging();
-            logger = null;
+        if (!logger.isLogging()) {
+            return;
         }
+
+        logger.stopLogging();
+        application.unregisterActivityLifecycleCallbacks(logger);
     }
 
     public static boolean isLogging() {
-        return logger != null;
+        return logger.isLogging();
     }
 }

--- a/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.java
+++ b/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.java
@@ -7,9 +7,7 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -22,6 +20,8 @@ import java.util.Map;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class TooLargeTool {
+
+    private static ActivitySavedStateLogger sLogger;
 
     private TooLargeTool() {
         // Static only
@@ -161,6 +161,26 @@ public final class TooLargeTool {
      * @param tag for log messages
      */
     public static void startLogging(Application application, int priority, @NonNull String tag) {
-        application.registerActivityLifecycleCallbacks(new ActivitySavedStateLogger(priority, tag, true));
+        if (sLogger == null) {
+            sLogger = new ActivitySavedStateLogger(priority, tag, true);
+            application.registerActivityLifecycleCallbacks(sLogger);
+        }
+    }
+
+    /**
+     * Stop all logging.
+     *
+     * @param application to stop logging
+     */
+    public static void stopLogging(Application application) {
+        if (sLogger != null) {
+            application.unregisterActivityLifecycleCallbacks(sLogger);
+            sLogger.stopLogging();
+            sLogger = null;
+        }
+    }
+
+    public static boolean isLogged() {
+        return sLogger != null;
     }
 }

--- a/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.java
+++ b/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.HashMap;
@@ -21,7 +22,7 @@ import java.util.Map;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class TooLargeTool {
 
-    private static ActivitySavedStateLogger sLogger;
+    @Nullable private static ActivitySavedStateLogger logger;
 
     private TooLargeTool() {
         // Static only
@@ -161,9 +162,9 @@ public final class TooLargeTool {
      * @param tag for log messages
      */
     public static void startLogging(Application application, int priority, @NonNull String tag) {
-        if (sLogger == null) {
-            sLogger = new ActivitySavedStateLogger(priority, tag, true);
-            application.registerActivityLifecycleCallbacks(sLogger);
+        if (logger == null) {
+            logger = new ActivitySavedStateLogger(priority, tag, true);
+            application.registerActivityLifecycleCallbacks(logger);
         }
     }
 
@@ -173,14 +174,14 @@ public final class TooLargeTool {
      * @param application to stop logging
      */
     public static void stopLogging(Application application) {
-        if (sLogger != null) {
-            application.unregisterActivityLifecycleCallbacks(sLogger);
-            sLogger.stopLogging();
-            sLogger = null;
+        if (logger != null) {
+            application.unregisterActivityLifecycleCallbacks(logger);
+            logger.stopLogging();
+            logger = null;
         }
     }
 
-    public static boolean isLogged() {
-        return sLogger != null;
+    public static boolean isLogging() {
+        return logger != null;
     }
 }


### PR DESCRIPTION
Hi Max

It's not necessary to have TooLargeTool always enabled, because it can pollut logs, that's why it would be convinient to have an API to turn it off.