### PR TITLE
Add the ability to detect and log TransactionTooLargeExceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-beta01'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Fri May 10 12:01:18 BST 2019
+#Tue Feb 18 17:54:45 UYT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-rc-1-all.zip
-
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/toolargetool/src/main/java/com/gu/toolargetool/ActivitySavedStateLogger.kt
+++ b/toolargetool/src/main/java/com/gu/toolargetool/ActivitySavedStateLogger.kt
@@ -35,11 +35,23 @@ class ActivitySavedStateLogger(
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle?) {
         if (isLogging && (outState != null)) {
             savedStates[activity] = outState
+            if (sizeAsParcel(outState) > TooLargeTool.MAXIMUM_SIZE_IN_BYTES) {
+                logTransactionTooLargeDetected(activity, outState)
+            }
         }
     }
 
     override fun onActivityStopped(activity: Activity) {
         logAndRemoveSavedState(activity)
+    }
+
+    private fun logTransactionTooLargeDetected(activity: Activity, bundle: Bundle) {
+        try {
+            val message = formatter.format(activity, bundle)
+            logger.logTransactionTooLargeDetected(message)
+        } catch (e: RuntimeException) {
+            logger.logException(e)
+        }
     }
 
     private fun logAndRemoveSavedState(activity: Activity) {

--- a/toolargetool/src/main/java/com/gu/toolargetool/Logger.kt
+++ b/toolargetool/src/main/java/com/gu/toolargetool/Logger.kt
@@ -8,6 +8,7 @@ import android.util.Log
  */
 interface Logger {
     fun log(msg: String)
+    fun logTransactionTooLargeDetected(msg: String)
     fun logException(e: Exception)
 }
 
@@ -24,5 +25,9 @@ class LogcatLogger(private val priority: Int = Log.DEBUG, private val tag: Strin
 
     override fun logException(e: Exception) {
         Log.w(tag, e.message, e)
+    }
+
+    override fun logTransactionTooLargeDetected(msg: String) {
+        Log.e(tag, "TransactionTooLarge detected: $msg")
     }
 }

--- a/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.kt
+++ b/toolargetool/src/main/java/com/gu/toolargetool/TooLargeTool.kt
@@ -16,7 +16,7 @@ import java.util.*
  * [Application.onCreate] method.
  */
 object TooLargeTool {
-
+    internal const val MAXIMUM_SIZE_IN_BYTES = 1000000 // 1mb https://developer.android.com/reference/android/os/TransactionTooLargeException
     private var activityLogger: ActivitySavedStateLogger? = null
 
     @JvmStatic


### PR DESCRIPTION
Right now if a `TransactionTooLargeException` happens, the library is not logging the error