### PR TITLE
Build updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation project(path: ':toolargetool')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation project(path: ':toolargetool')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.gu.toolargetool.sample"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/gu/toolargetool/sample/MainActivity.kt
+++ b/app/src/main/java/com/gu/toolargetool/sample/MainActivity.kt
@@ -18,8 +18,8 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState?.putString("MainActivity.test", "MainActivity put this string here.")
+        outState.putString("MainActivity.test", "MainActivity put this string here.")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.4.20'
     repositories {
         jcenter()
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-beta01'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Fri May 10 12:01:18 BST 2019
+#Mon Jan 25 15:23:35 GMT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-rc-1-all.zip
-
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/toolargetool/bintray.gradle
+++ b/toolargetool/bintray.gradle
@@ -1,6 +1,6 @@
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+    archiveClassifier.set('sources')
 }
 
 artifacts {

--- a/toolargetool/build.gradle
+++ b/toolargetool/build.gradle
@@ -18,7 +18,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'

--- a/toolargetool/build.gradle
+++ b/toolargetool/build.gradle
@@ -19,7 +19,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.1'

--- a/toolargetool/build.gradle
+++ b/toolargetool/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/toolargetool/src/main/java/com/gu/toolargetool/ActivitySavedStateLogger.kt
+++ b/toolargetool/src/main/java/com/gu/toolargetool/ActivitySavedStateLogger.kt
@@ -32,8 +32,8 @@ class ActivitySavedStateLogger(
         logAndRemoveSavedState(activity)
     }
 
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle?) {
-        if (isLogging && (outState != null)) {
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        if (isLogging) {
             savedStates[activity] = outState
         }
     }


### PR DESCRIPTION
Some updates to various build/library dependencies, including a switch to `kotlin-stdlib` which should resolve issues #29 and #30.

Details:

* Updated gradle wrapper: `5.4-rc-1` -> `6.5`
* Updated gradle plugin: `3.5.0-beta01` -> `4.1.2`
* Kotlin: `1.3.31` -> `1.4.20`
* Android `compile|targetSdkVersion`: `28` -> `30`
* App compat: `1.0.2` -> `1.2.0`
* Fixed build warning about using deprecated `classifier` property for `sourcesJar` task.
* Switched from `kotlin-stdlib-jdk7` to `kotlin-stdlib`

I've called this branch `release-0.2.2` but I think I will release these changes as `0.3.0` taking into account the `kotlin-stdlib` switch which may enable those Java-only apps to use the library as intended.