### PR TITLE
Add GitHub Workflow for publishing snapshot releases

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -3,6 +3,7 @@ name: Publish snapshots
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,25 @@
+name: Publish snapshots
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Publish with gradlew
+        run: ./gradlew -Psnapshot :toolargetool:publishReleasePublicationToSonatypeRepository

--- a/toolargetool/build.gradle.kts
+++ b/toolargetool/build.gradle.kts
@@ -43,6 +43,8 @@ val javadocJar by tasks.creating(Jar::class) {
 
 afterEvaluate {
     publishing {
+        val isSnapshot = project.hasProperty("snapshot")
+
         publications {
             val release by creating(MavenPublication::class) {
                 from(components["release"])
@@ -51,7 +53,7 @@ afterEvaluate {
 
                 groupId = "com.gu.android"
                 artifactId = "toolargetool"
-                version = "0.3.0"
+                version = "0.3.0" + if (isSnapshot) "-SNAPSHOT" else ""
 
                 pom {
                     name.set("toolargetool")
@@ -84,24 +86,18 @@ afterEvaluate {
         }
 
         repositories {
-            val ossrhUsername = properties["ossrhUsername"] as? String
-                    ?: System.getenv("OSSRH_USERNAME")
-            val ossrhPassword = properties["ossrhPassword"] as? String
-                    ?: System.getenv("OSSRH_PASSWORD")
             maven {
-                name = "snapshot"
-                url = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+                name = "Sonatype"
+                url = uri("https://oss.sonatype.org" + if(isSnapshot) {
+                    "/content/repositories/snapshots/"
+                } else {
+                    "/local/staging/deploy/maven2/"
+                })
                 credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
-                }
-            }
-            maven {
-                name = "staging"
-                url = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+                    username = properties["ossrhUsername"] as? String
+                            ?: System.getenv("OSSRH_USERNAME")
+                    password = properties["ossrhPassword"] as? String
+                            ?: System.getenv("OSSRH_PASSWORD")
                 }
             }
         }


### PR DESCRIPTION
This PR modifies the `publishing` block in `toolargetool/build.gradle` to utilise a new `snapshot` project property. This parameter modifies the version number and controls the URL of the Sonatype publishing repo to ensure those are consistent with one another.

The `publish-snapshot.yml` workflow utilises this new project property to make snapshot releases to Sonatype whenever `main` has new commits.